### PR TITLE
Fixed cpantester fail report by upgrading to Map::Tube v3.50.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,5 +40,5 @@ repository.type = git
 
 [Prereqs]
 perl = 5.010
-Map::Tube = 3.49
+Map::Tube = 3.50
 Test::Map::Tube = 0.35


### PR DESCRIPTION
Hi @reneeb 

As promised my first PR :-)
Your map did raise a very valid question about taint check.
None of the maps so far had this error. You picked it by add "-T" switch to the test script "t/map.t".
Glad that you did and I had to get it fixed.

One sample fail report:
http://www.cpantesters.org/cpan/report/17ff4a44-46d4-11e8-9da6-f703c768dc7a

I have pushed the Map::Tube v3.50, which should solve the issue.

Many Thanks.
Best Regards,
Mohammad S Anwar